### PR TITLE
Fix: Prefix confusion, overwriting params

### DIFF
--- a/a3ue_pcf/addons/core/Includes/script_mod.hpp
+++ b/a3ue_pcf/addons/core/Includes/script_mod.hpp
@@ -1,6 +1,6 @@
 #define MAINPREFIX x
 #ifndef PREFIX
-    #define PREFIX A3A
+    #define PREFIX A3APCF
 #endif
 
 #include "script_version.hpp"

--- a/a3ue_pcf/addons/core/Params.hpp
+++ b/a3ue_pcf/addons/core/Params.hpp
@@ -1,6 +1,6 @@
 class Params
 {
-    class AllParams {};
+    class AllParams;
 
     // class AIParams : AllParams { type = "AI"; };
     // class RebelBalanceParams : AIParams { type = "RebelBalance"; };
@@ -55,7 +55,17 @@ class Params
     //         default = 100;
     //     };
 
-    class ExtenderParams : AllParams {};
+    class BuilderParams;
+    class maxConstructions: BuilderParams
+    {
+        title = $STR_params_maxConstructions;
+        tooltip = $STR_params_maxConstructions_desc;
+        values[] = {0,50,100,250,355,500,750,1000,5000};                    //PCF added 500, 750, 1000 and 5000.
+        texts[] = {"0","50","100","250","355","500","750","1000","5000"};   //PCF added 500, 750, 1000 and 5000.
+        default = 100;
+    };
+
+    class ExtenderParams;
         // PCF Params start
         class PCF_ParametersSpacer1 : AllParams {};
         class TitlePCF : ExtenderParams


### PR DESCRIPTION
(In regards to [this](https://discord.com/channels/817005365740044289/1188501758859808788/1486795735809654955) conversation)

### To explain the big issue and the one that honestly happens to the best of us:

When the prefix isn't changed, your [ADDON](https://github.com/CBATeam/CBA_A3/blob/510e207e2c68f7a3e94be8eb67de8cf919d4b3b8/addons/main/script_macros_common.hpp#L58) compiles to `A3A_core` since [PREFIX](https://github.com/Land-Strider/A3UEPCF/blob/86728e4dec3ee6c44895390267a87d439051b3da/a3ue_pcf/addons/core/Includes/script_mod.hpp#L2-L4) wasn't changed. This now becomes your CfgPatches entry prefix for your core and scrt addons (`PREFIX_COMPONENT`). 

So when you tell the game to load your ADDON (`A3A_core`) after `A3A_core`... it doesn't have a clue what to do. By changing the PREFIX to `A3APCF`, this makes your CfgPatches entries become `A3APCF_component`, e.g `A3APFC_core`. Now, the game knows to load *your* addon after the original `A3A_core`. Normally this isn't an issue, till you start overwriting certain things - like in this case, `maxConstructions`.

Does this change have unintended consequences? Possibly, but it fixes your param issue

### For the config part:
This one is a minor nitpick and doesn't actually cause any issues iirc

When we create a new class, but define it as `class Whatever {};` instead of `class Whatever;` it *can* confuse the engine sometimes. In this instance I don't think it does, though it's a fair thing to note and try to avoid. Have a read of [this](https://community.bistudio.com/wiki/Class_Inheritance) if you haven't already